### PR TITLE
Replace pathPrefix variable with segmentCount

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,17 +17,19 @@
       // with Internet Explorer (it is currently > 512 bytes)
 
       // If you're creating a Project Pages site and NOT using a custom domain,
-      // then set pathPrefix = true. This way the repo name will remain in the path:
+      // then set segmentCount to the number of segments in your path. This
+      // way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides:
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?p=/one/two&q=a=b~and~c=d#qwe
-      // Otherwise, leave pathPrefix as false.
-      var pathPrefix = false;
+      // Otherwise, leave segmentCount as 0.
+      var segmentCount = 0;
 
       var l = window.location;
       l.replace(
         l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
-        l.pathname.split('/').slice(0, 2 * pathPrefix).join('/') + '/?p=/' +
-        l.pathname.slice(1).split('/').slice(pathPrefix).join('/').replace(/&/g, '~and~') +
+        l.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?p=/' +
+        l.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
         (l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '') +
         l.hash
       );


### PR DESCRIPTION
Previously it was only possible for the root URL of the app to have
0 or 1 path segments in the URL.  Now, the segmentCount variable can
be used to specify the number of segments to retain when replacing
the path with a param.